### PR TITLE
modified Transactions.Get to use async, added vin[].addresses

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -1,3 +1,4 @@
+var async = require("async");
 
 function standardizeTransaction(resp){
   var response = {};
@@ -12,7 +13,7 @@ function standardizeTransaction(resp){
   response.vout = [];
   resp.inputs.forEach(function (input){
     response.vin.push({txid: input.output_hash, txId: input.output_hash, vout: input.output_index, 
-                        scriptSig: {asm: null, hex: input.script_signature}, sequence: null});
+                        scriptSig: {asm: null, hex: input.script_signature}, sequence: null, addresses: input.addresses});
   });
   resp.outputs.forEach(function (output){
     response.vout.push({value: output.value, index: output.output_index, n: output.output_index, spentTxid: output.spending_transaction || null,
@@ -41,21 +42,17 @@ var Transactions = function(opts){
   //returns a list of transaction objects. Check the README.md for an example transaction object.
   function Get(transactions, callback){
     var responseData = [];
-    var count = 0;
-
-    transactions.forEach(function (txid){
-      opts.chain.getTransaction(txid, function (err, resp){
-        if (err){
-          var error = err.resp.body || err;
-          callback(error, null);
-        } else {
+    async.each(transactions,
+      function(txid, cb) {
+        opts.chain.getTransaction(txid, function (err, resp){
           responseData.push(standardizeTransaction(resp));
-          if (++count === transactions.length){
-            callback(null, responseData);
-          }
-        }
-      });
-    });
+          cb(null, resp);
+        });
+      },
+      function(err) {
+        callback(err, responseData);
+      }
+    );
   }
   
   //expects a callback(err, resp)

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   },
   "homepage": "https://github.com/andrewmalta13/chain-unofficial",
   "devDependencies": {
-    "abstract-common-blockchain": "^0.1.0",
+    "abstract-common-blockchain": "^0.1.4",
+    "async": "^1.3.0",
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "abstract-common-blockchain": "^0.1.0",
     "chain-node": "^3.1.2",
     "tape": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
   },
   "homepage": "https://github.com/andrewmalta13/chain-unofficial",
   "devDependencies": {
-    "abstract-common-blockchain": "^0.1.4",
+    "abstract-common-blockchain": "^0.1.5",
     "async": "^1.3.0",
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "abstract-common-blockchain": "^0.1.5",
     "chain-node": "^3.1.2",
     "tape": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
+    "abstract-common-blockchain": "^0.1.5",
     "chain-node": "^3.1.2",
     "tape": "^4.0.0"
   }


### PR DESCRIPTION
So it turns out that we're missing some information in vin[]... each input needs an addresses array. This is used by opentip when determining the difference between a change address and the value of the tip.

Also, I modified Transactions.Get to be async as Chain was having some issues with batch gets.

Let me know when you've merged and published the changes!
